### PR TITLE
IONOS(mail): evaluate mailbox possible flag to hide mailbox creation

### DIFF
--- a/lib/Provider/MailAccountProvider/Implementations/Ionos/Service/IonosConfigService.php
+++ b/lib/Provider/MailAccountProvider/Implementations/Ionos/Service/IonosConfigService.php
@@ -164,6 +164,19 @@ class IonosConfigService {
 	}
 
 	/**
+	 * Check if mailbox creation is possible for this instance.
+	 *
+	 * This flag is provided by the operator via the IONOS_MAILBOX_POSSIBLE environment
+	 * variable (set by PSS through the helm chart). It is only true when a customer
+	 * domain is connected to the instance.
+	 *
+	 * @return bool True if mailbox creation is possible, false otherwise
+	 */
+	public function isMailboxPossible(): bool {
+		return $this->config->getSystemValue('ncw.mailboxPossible', '') === 'true';
+	}
+
+	/**
 	 * Check if IONOS integration is fully enabled and configured
 	 *
 	 * Returns true only if:

--- a/lib/Provider/MailAccountProvider/Implementations/Ionos/Service/IonosMailConfigService.php
+++ b/lib/Provider/MailAccountProvider/Implementations/Ionos/Service/IonosMailConfigService.php
@@ -44,6 +44,15 @@ class IonosMailConfigService {
 				return false;
 			}
 
+			// Check if mailbox creation is possible for this instance.
+			// This flag is set by the operator (via IONOS_MAILBOX_POSSIBLE env var) and reflects
+			// whether a customer domain is connected. Without a customer domain, mailbox creation
+			// must not be offered.
+			if (!$this->ionosConfigService->isMailboxPossible()) {
+				$this->logger->debug('IONOS mail config not available - mailbox creation not possible for this instance');
+				return false;
+			}
+
 			// Get user ID - either from parameter or from session
 			if ($userId === null) {
 				$user = $this->userSession->getUser();

--- a/tests/Unit/Provider/MailAccountProvider/Implementations/Ionos/Service/IonosConfigServiceTest.php
+++ b/tests/Unit/Provider/MailAccountProvider/Implementations/Ionos/Service/IonosConfigServiceTest.php
@@ -232,6 +232,33 @@ class IonosConfigServiceTest extends TestCase {
 		$this->assertEquals('example.com', $result);
 	}
 
+	public function testIsMailboxPossibleWhenTrue(): void {
+		$this->config->method('getSystemValue')
+			->with('ncw.mailboxPossible', '')
+			->willReturn('true');
+
+		$result = $this->service->isMailboxPossible();
+		$this->assertTrue($result);
+	}
+
+	public function testIsMailboxPossibleWhenFalse(): void {
+		$this->config->method('getSystemValue')
+			->with('ncw.mailboxPossible', '')
+			->willReturn('false');
+
+		$result = $this->service->isMailboxPossible();
+		$this->assertFalse($result);
+	}
+
+	public function testIsMailboxPossibleWhenEmpty(): void {
+		$this->config->method('getSystemValue')
+			->with('ncw.mailboxPossible', '')
+			->willReturn('');
+
+		$result = $this->service->isMailboxPossible();
+		$this->assertFalse($result);
+	}
+
 	public function testIsMailConfigEnabledWhenEnabled(): void {
 		$this->config->method('getAppValue')
 			->with('mail', 'ionos-mailconfig-enabled', 'no')

--- a/tests/Unit/Provider/MailAccountProvider/Implementations/Ionos/Service/IonosMailConfigServiceTest.php
+++ b/tests/Unit/Provider/MailAccountProvider/Implementations/Ionos/Service/IonosMailConfigServiceTest.php
@@ -45,6 +45,27 @@ class IonosMailConfigServiceTest extends TestCase {
 		);
 	}
 
+	public function testIsMailConfigAvailableReturnsFalseWhenMailboxNotPossible(): void {
+		$this->ionosConfigService->expects($this->once())
+			->method('isIonosIntegrationEnabled')
+			->willReturn(true);
+
+		$this->ionosConfigService->expects($this->once())
+			->method('isMailboxPossible')
+			->willReturn(false);
+
+		$this->logger->expects($this->once())
+			->method('debug')
+			->with('IONOS mail config not available - mailbox creation not possible for this instance');
+
+		$this->userSession->expects($this->never())
+			->method('getUser');
+
+		$result = $this->service->isMailConfigAvailable();
+
+		$this->assertFalse($result);
+	}
+
 	public function testIsMailConfigAvailableReturnsFalseWhenFeatureDisabled(): void {
 		$this->ionosConfigService->expects($this->once())
 			->method('isIonosIntegrationEnabled')
@@ -61,6 +82,10 @@ class IonosMailConfigServiceTest extends TestCase {
 	public function testIsMailConfigAvailableReturnsFalseWhenNoUserSession(): void {
 		$this->ionosConfigService->expects($this->once())
 			->method('isIonosIntegrationEnabled')
+			->willReturn(true);
+
+		$this->ionosConfigService->expects($this->once())
+			->method('isMailboxPossible')
 			->willReturn(true);
 
 		$this->userSession->expects($this->once())
@@ -82,6 +107,10 @@ class IonosMailConfigServiceTest extends TestCase {
 
 		$this->ionosConfigService->expects($this->once())
 			->method('isIonosIntegrationEnabled')
+			->willReturn(true);
+
+		$this->ionosConfigService->expects($this->once())
+			->method('isMailboxPossible')
 			->willReturn(true);
 
 		$this->userSession->expects($this->once())
@@ -106,6 +135,10 @@ class IonosMailConfigServiceTest extends TestCase {
 
 		$this->ionosConfigService->expects($this->once())
 			->method('isIonosIntegrationEnabled')
+			->willReturn(true);
+
+		$this->ionosConfigService->expects($this->once())
+			->method('isMailboxPossible')
 			->willReturn(true);
 
 		$this->userSession->expects($this->once())
@@ -147,6 +180,10 @@ class IonosMailConfigServiceTest extends TestCase {
 			->method('isIonosIntegrationEnabled')
 			->willReturn(true);
 
+		$this->ionosConfigService->expects($this->once())
+			->method('isMailboxPossible')
+			->willReturn(true);
+
 		$this->userSession->expects($this->once())
 			->method('getUser')
 			->willReturn($user);
@@ -184,6 +221,10 @@ class IonosMailConfigServiceTest extends TestCase {
 			->method('isIonosIntegrationEnabled')
 			->willReturn(true);
 
+		$this->ionosConfigService->expects($this->once())
+			->method('isMailboxPossible')
+			->willReturn(true);
+
 		$this->userSession->expects($this->once())
 			->method('getUser')
 			->willReturn($user);
@@ -214,6 +255,10 @@ class IonosMailConfigServiceTest extends TestCase {
 			->method('isIonosIntegrationEnabled')
 			->willReturn(true);
 
+		$this->ionosConfigService->expects($this->once())
+			->method('isMailboxPossible')
+			->willReturn(true);
+
 		// When userId is provided, userSession should NOT be called
 		$this->userSession->expects($this->never())
 			->method('getUser');
@@ -233,6 +278,10 @@ class IonosMailConfigServiceTest extends TestCase {
 	public function testIsMailConfigAvailableWithExplicitUserIdReturnsTrueWhenUserHasRemoteAccountButNotLocal(): void {
 		$this->ionosConfigService->expects($this->once())
 			->method('isIonosIntegrationEnabled')
+			->willReturn(true);
+
+		$this->ionosConfigService->expects($this->once())
+			->method('isMailboxPossible')
 			->willReturn(true);
 
 		// When userId is provided, userSession should NOT be called
@@ -267,6 +316,10 @@ class IonosMailConfigServiceTest extends TestCase {
 	public function testIsMailConfigAvailableReturnsFalseOnException(): void {
 		$this->ionosConfigService->expects($this->once())
 			->method('isIonosIntegrationEnabled')
+			->willReturn(true);
+
+		$this->ionosConfigService->expects($this->once())
+			->method('isMailboxPossible')
 			->willReturn(true);
 
 		$exception = new \Exception('Test exception');


### PR DESCRIPTION
This pull request introduces a new configuration flag to control whether mailbox creation is possible for an instance, based on whether a customer domain is connected. The implementation includes the flag in business logic and adds comprehensive unit tests to ensure correct behavior.

**Feature: Mailbox Creation Control**

* Added `isMailboxPossible()` method to `IonosConfigService` to check the new `ncw.mailboxPossible` system value, which determines if mailbox creation is allowed for the instance. This is set via the `IONOS_MAILBOX_POSSIBLE` environment variable.
* Updated `isMailConfigAvailable()` in `IonosMailConfigService` to return `false` if mailbox creation is not possible, logging a debug message and preventing further checks.